### PR TITLE
feat: Copy & Paste JSON using Clipboard API

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@material-ui/core": "3.8.3",
     "@material-ui/icons": "3.0.2",
     "@types/jest": "23.3.12",
+    "@types/navigator-permissions": "0.1.0",
     "@types/node": "10.12.18",
     "@types/react": "16.7.18",
     "@types/react-dom": "16.0.11",

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -81,7 +81,7 @@ class Content extends React.Component<Props, State> {
 
   get hasClipboardSupport() {
     const hasClipboardAPI = typeof (navigator as any).clipboard !== 'undefined';
-    const isntFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') === -1;
+    const isNotFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') === -1;
     return hasClipboardAPI && isntFirefox;
   }
 

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -82,7 +82,7 @@ class Content extends React.Component<Props, State> {
   get hasClipboardSupport() {
     const hasClipboardAPI = typeof (navigator as any).clipboard !== 'undefined';
     const isNotFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') === -1;
-    return hasClipboardAPI && isntFirefox;
+    return hasClipboardAPI && isNotFirefox;
   }
 
   copyToClipboard = async (event: React.MouseEvent<HTMLInputElement>) => {

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -1,10 +1,23 @@
-import {Grid, Paper, TextField, Theme, Typography, WithStyles, createStyles, withStyles} from '@material-ui/core';
+import {
+  Button,
+  Grid,
+  Paper,
+  TextField,
+  Theme,
+  Typography,
+  WithStyles,
+  createStyles,
+  withStyles,
+} from '@material-ui/core';
 import * as React from 'react';
 
 const jsonAbc = require('jsonabc');
 
 const styles = (theme: Theme) =>
   createStyles({
+    Button: {
+      margin: theme.spacing.unit,
+    },
     Pane: {
       margin: '20px',
       padding: theme.spacing.unit * 2,
@@ -66,6 +79,38 @@ class Content extends React.Component<Props, State> {
     this.setState({input: event.currentTarget.value}, this.formatObject);
   };
 
+  get hasClipboardSupport() {
+    const hasClipboardAPI = typeof (navigator as any).clipboard !== 'undefined';
+    const isntFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') === -1;
+    return hasClipboardAPI && isntFirefox;
+  }
+
+  copyToClipboard = async (event: React.MouseEvent<HTMLInputElement>) => {
+    const nav = navigator as NavigatorPermissions.NavigatorPermissions;
+    if (nav.permissions) {
+      const result = await nav.permissions.query({name: 'clipboard-write'});
+      if (result.state == 'granted' || result.state == 'prompt') {
+        (navigator as any).clipboard.writeText(this.state.output);
+      }
+    }
+  };
+
+  pasteFromClipboard = async (event: React.MouseEvent<HTMLInputElement>) => {
+    const nav = navigator as NavigatorPermissions.NavigatorPermissions;
+    if (nav.permissions) {
+      const result = await nav.permissions.query({name: 'clipboard-read'});
+      if (result.state == 'granted' || result.state == 'prompt') {
+        const pasteText = await (navigator as any).clipboard.readText();
+        this.setState(
+          {
+            input: pasteText,
+          },
+          this.formatObject
+        );
+      }
+    }
+  };
+
   componentDidMount() {
     this.formatJSON();
   }
@@ -83,17 +128,23 @@ class Content extends React.Component<Props, State> {
             <TextField
               fullWidth
               helperText={this.state.inputInfo}
+              id="jsonInput"
               multiline={true}
               onChange={this.handleInput}
-              placeholder={this.state.input}
               rows={4}
               rowsMax={Infinity}
               style={{margin: 8}}
+              value={this.state.input}
               variant="filled"
               InputLabelProps={{
                 shrink: true,
               }}
             />
+            {this.hasClipboardSupport && (
+              <Button className={classes.Button} color="inherit" onClick={this.pasteFromClipboard} variant="contained">
+                Paste
+              </Button>
+            )}
           </Paper>
         </Grid>
         <Grid item xs={12} sm={6}>
@@ -105,6 +156,7 @@ class Content extends React.Component<Props, State> {
               disabled
               fullWidth
               helperText={this.state.outputInfo}
+              id="jsonOutput"
               multiline={true}
               rows={4}
               rowsMax={Infinity}
@@ -115,6 +167,11 @@ class Content extends React.Component<Props, State> {
                 shrink: true,
               }}
             />
+            {this.hasClipboardSupport && (
+              <Button className={classes.Button} color="inherit" onClick={this.copyToClipboard} variant="contained">
+                Copy
+              </Button>
+            )}
           </Paper>
         </Grid>
       </Grid>

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -91,6 +91,9 @@ class Content extends React.Component<Props, State> {
       const result = await nav.permissions.query({name: 'clipboard-write'});
       if (result.state == 'granted' || result.state == 'prompt') {
         (navigator as any).clipboard.writeText(this.state.output);
+        this.setState({
+          outputInfo: 'Copied output into clipboard.',
+        });
       }
     }
   };
@@ -104,6 +107,7 @@ class Content extends React.Component<Props, State> {
         this.setState(
           {
             input: pasteText,
+            inputInfo: 'Pasted clipboard content into input.',
           },
           this.formatObject
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1010,6 +1010,11 @@
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"
 
+"@types/navigator-permissions@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/navigator-permissions/-/navigator-permissions-0.1.0.tgz#c22c4a04f0bdae92b042b0bfaf7f72ff152188c2"
+  integrity sha512-qLj3n10Va96m0cjHvDgXBxEh84vxza26iErlTOQMqBQSyMnfO0mSjDFcC/XiY4x7FyWGI2aHjBauic/obfc26g==
+
 "@types/node@10.12.18":
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"


### PR DESCRIPTION
With Chrome 66+ ([see Platform status](https://www.chromestatus.com/feature/5861289330999296)) it's now possible to copy and paste JSON using the Clipboard API.

Firefox unfortunately doesn't support this using the native API ([read here](https://bugzilla.mozilla.org/show_bug.cgi?id=1312260#c53)).

**Screenshot**

![image](https://user-images.githubusercontent.com/469989/51091678-24b2c000-178e-11e9-972a-eb90b8c26331.png)
