### PR TITLE
refactor: Use hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "json5": "2.1.0",
     "jsonabc": "2.3.1",
     "mdi-material-ui": "5.9.0",
-    "react": "16.7.0",
-    "react-dom": "16.7.0",
+    "react": "16.8.0",
+    "react-dom": "16.8.0",
     "react-scripts": "2.1.3",
     "typescript": "3.3.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,18 +3,14 @@ import {AppProvider} from './AppProvider';
 import {AppTheme} from './AppTheme';
 import {Content, Footer, Header} from './components/layout/';
 
-class App extends React.Component {
-  render() {
-    return (
-      <AppProvider>
-        <AppTheme>
-          <Header />
-          <Content />
-          <Footer />
-        </AppTheme>
-      </AppProvider>
-    );
-  }
-}
+const App = () => (
+  <AppProvider>
+    <AppTheme>
+      <Header />
+      <Content />
+      <Footer />
+    </AppTheme>
+  </AppProvider>
+);
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {AppProvider} from './AppProvider';
-import AppTheme from './AppTheme';
+import {AppTheme} from './AppTheme';
 import {Content, Footer, Header} from './components/layout/';
 
 class App extends React.Component {

--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -1,5 +1,5 @@
 import {PaletteType} from '@material-ui/core';
-import React from 'react';
+import React, {ContextType, Provider, useState} from 'react';
 import AppTheme from './AppTheme';
 
 interface Context {
@@ -18,42 +18,27 @@ const AppContext = React.createContext<Context>({
   },
 });
 
-interface Props {}
-
 interface State {
   theme: PaletteType;
 }
 
-class AppProvider extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      theme: AppTheme.getTheme(),
-    };
-  }
-
-  render() {
-    return (
-      <AppContext.Provider
-        value={{
-          action: {
-            switchTheme: (name: PaletteType) =>
-              this.setState(
-                {
-                  theme: name,
-                },
-                () => {
-                  AppTheme.setTheme(this.state.theme);
-                }
-              ),
+const AppProvider = ({children}: React.Props<Context>) => {
+  const [theme, setTheme] = useState(AppTheme.getTheme());
+  return (
+    <AppContext.Provider
+      value={{
+        action: {
+          switchTheme: (name: PaletteType) => {
+            setTheme(name);
+            AppTheme.setTheme(name);
           },
-          state: this.state,
-        }}
-      >
-        {this.props.children}
-      </AppContext.Provider>
-    );
-  }
-}
+        },
+        state: {theme},
+      }}
+    >
+      {children}
+    </AppContext.Provider>
+  );
+};
 
 export {AppContext, AppProvider};

--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -7,14 +7,14 @@ interface State {
 }
 interface Context {
   action: {
-    switchTheme: (name: PaletteType) => void;
+    switchTheme: () => void;
   };
   state: State;
 }
 
 const AppContext = React.createContext<Context>({
   action: {
-    switchTheme: (name: PaletteType) => {},
+    switchTheme: () => {},
   },
   state: {
     theme: 'light',
@@ -27,9 +27,10 @@ const AppProvider = ({children}: React.Props<Context>) => {
     <AppContext.Provider
       value={{
         action: {
-          switchTheme: (name: PaletteType) => {
-            setTheme(name);
-            saveTheme(name);
+          switchTheme: () => {
+            const newTheme = theme === 'dark' ? 'light' : 'dark';
+            setTheme(newTheme);
+            saveTheme(newTheme);
           },
         },
         state: {theme},

--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -1,7 +1,10 @@
 import {PaletteType} from '@material-ui/core';
-import React, {ContextType, Provider, useState} from 'react';
-import AppTheme from './AppTheme';
+import React, {useState} from 'react';
+import {loadTheme, saveTheme} from './AppTheme';
 
+interface State {
+  theme: PaletteType;
+}
 interface Context {
   action: {
     switchTheme: (name: PaletteType) => void;
@@ -18,19 +21,15 @@ const AppContext = React.createContext<Context>({
   },
 });
 
-interface State {
-  theme: PaletteType;
-}
-
 const AppProvider = ({children}: React.Props<Context>) => {
-  const [theme, setTheme] = useState(AppTheme.getTheme());
+  const [theme, setTheme] = useState(loadTheme());
   return (
     <AppContext.Provider
       value={{
         action: {
           switchTheme: (name: PaletteType) => {
             setTheme(name);
-            AppTheme.setTheme(name);
+            saveTheme(name);
           },
         },
         state: {theme},

--- a/src/AppTheme.tsx
+++ b/src/AppTheme.tsx
@@ -1,44 +1,38 @@
 import {CssBaseline, MuiThemeProvider, PaletteType, createMuiTheme} from '@material-ui/core';
-import React from 'react';
+import {MuiThemeProviderProps} from '@material-ui/core/styles/MuiThemeProvider';
+import React, {useContext} from 'react';
 import {AppContext} from './AppProvider';
 
-class AppTheme extends React.Component {
-  static getTheme(): PaletteType {
-    if (typeof localStorage !== 'undefined') {
-      const theme = localStorage.getItem('theme');
-      return theme === 'light' ? 'light' : 'dark';
-    } else {
-      return 'light';
-    }
-  }
+const hasLocalStorage = () => typeof localStorage !== 'undefined';
 
-  static setTheme(name: PaletteType) {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('theme', name);
-    }
-  }
+export const loadTheme = (): PaletteType => {
+  const theme = hasLocalStorage() && localStorage.getItem('theme');
+  return theme === 'dark' ? 'dark' : 'light';
+};
 
-  render() {
-    return (
-      <AppContext.Consumer>
-        {context => (
-          <MuiThemeProvider
-            theme={createMuiTheme({
-              palette: {
-                type: context.state.theme,
-              },
-              typography: {
-                useNextVariants: true,
-              },
-            })}
-          >
-            <CssBaseline />
-            {this.props.children}
-          </MuiThemeProvider>
-        )}
-      </AppContext.Consumer>
-    );
+export const saveTheme = (name: PaletteType) => {
+  if (hasLocalStorage()) {
+    localStorage.setItem('theme', name);
   }
-}
+};
+
+export const AppTheme = ({children}: React.Props<MuiThemeProviderProps>) => {
+  const {state} = useContext(AppContext);
+  return (
+    <MuiThemeProvider
+      theme={createMuiTheme({
+        palette: {
+          type: state.theme,
+        },
+        typography: {
+          useNextVariants: true,
+        },
+      })}
+    >
+      <CssBaseline />
+      {children}
+    </MuiThemeProvider>
+  );
+};
 
 export default AppTheme;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,18 +5,16 @@ import {
   FormGroup,
   IconButton,
   Switch,
-  Theme,
   Typography,
   WithStyles,
   createStyles,
   withStyles,
 } from '@material-ui/core';
 import {GithubCircle} from 'mdi-material-ui';
-import React from 'react';
+import React, {useContext} from 'react';
 import {AppContext} from '../../AppProvider';
-import AppTheme from '../../AppTheme';
 
-const styles = (theme: Theme) =>
+const styles = () =>
   createStyles({
     AppBarWrapper: {
       flexGrow: 1,
@@ -33,67 +31,37 @@ const styles = (theme: Theme) =>
 
 interface Props extends WithStyles<typeof styles> {}
 
-interface State {
-  inDarkMode: boolean;
-}
+const Header = ({classes}: Props) => {
+  const {state, action} = useContext(AppContext);
+  const inDarkMode = state.theme === 'dark';
 
-class Header extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      inDarkMode: AppTheme.getTheme() === 'dark',
-    };
-  }
-
-  render() {
-    const {classes} = this.props;
-
-    return (
-      <AppContext.Consumer>
-        {context => (
-          <div className={classes.AppBarWrapper}>
-            <AppBar color="default" position="static">
-              <FormControl>
-                <FormGroup row>
-                  <Typography className={classes.Title} color="inherit" variant="h5">
-                    Sort JSON
-                  </Typography>
-                  <FormControlLabel
-                    className={classes.DarkModeControl}
-                    control={
-                      <Switch
-                        color="primary"
-                        checked={this.state.inDarkMode}
-                        onChange={() => {
-                          this.setState(
-                            {
-                              inDarkMode: !this.state.inDarkMode,
-                            },
-                            () => {
-                              if (this.state.inDarkMode) {
-                                context.action.switchTheme('dark');
-                              } else {
-                                context.action.switchTheme('light');
-                              }
-                            }
-                          );
-                        }}
-                        value="inDarkMode"
-                      />
-                    }
-                    label="Dark Mode"
-                  />
-                  <IconButton color="inherit" href="https://github.com/ffflorian/sortjson.com">
-                    <GithubCircle />
-                  </IconButton>
-                </FormGroup>
-              </FormControl>
-            </AppBar>
-          </div>
-        )}
-      </AppContext.Consumer>
-    );
-  }
-}
+  return (
+    <div className={classes.AppBarWrapper}>
+      <AppBar color="default" position="static">
+        <FormControl>
+          <FormGroup row>
+            <Typography className={classes.Title} color="inherit" variant="h5">
+              Sort JSON
+            </Typography>
+            <FormControlLabel
+              className={classes.DarkModeControl}
+              control={
+                <Switch
+                  color="primary"
+                  checked={inDarkMode}
+                  onChange={() => action.switchTheme(inDarkMode ? 'light' : 'dark')}
+                />
+              }
+              label="Dark Mode"
+            />
+            <IconButton color="inherit" href="https://github.com/ffflorian/sortjson.com">
+              <GithubCircle />
+            </IconButton>
+          </FormGroup>
+        </FormControl>
+      </AppBar>
+    </div>
+  );
+};
 
 export default withStyles(styles)(Header);

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -45,13 +45,7 @@ const Header = ({classes}: Props) => {
             </Typography>
             <FormControlLabel
               className={classes.DarkModeControl}
-              control={
-                <Switch
-                  color="primary"
-                  checked={inDarkMode}
-                  onChange={() => action.switchTheme(inDarkMode ? 'light' : 'dark')}
-                />
-              }
+              control={<Switch color="primary" checked={inDarkMode} onChange={action.switchTheme} />}
               label="Dark Mode"
             />
             <IconButton color="inherit" href="https://github.com/ffflorian/sortjson.com">

--- a/yarn.lock
+++ b/yarn.lock
@@ -8609,15 +8609,15 @@ react-dev-utils@^7.0.1:
     strip-ansi "4.0.0"
     text-table "0.2.0"
 
-react-dom@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
-  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
+react-dom@16.8.0:
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.0.tgz#18f28d4be3571ed206672a267c66dd083145a9c4"
+  integrity sha512-dBzoAGYZpW9Yggp+CzBPC7q1HmWSeRc93DWrwbskmG1eHJWznZB/p0l/Sm+69leIGUS91AXPB/qB3WcPnKx8Sw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0"
+    scheduler "^0.13.0"
 
 react-error-overlay@^5.1.2:
   version "5.1.2"
@@ -8708,15 +8708,15 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@16.7.0:
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
-  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
+react@16.8.0:
+  version "16.8.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.0.tgz#8533f0e4af818f448a276eae71681d09e8dd970a"
+  integrity sha512-g+nikW2D48kqgWSPwNo0NH9tIGG3DsQFlrtrQ1kj6W77z5ahyIHG0w8kPpz4Sdj6gyLnz0lEd/xsjOoGge2MYQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.12.0"
+    scheduler "^0.13.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -9205,10 +9205,10 @@ saxes@^3.1.4:
   dependencies:
     xmlchars "^1.3.1"
 
-scheduler@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
-  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+scheduler@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.0.tgz#e701f62e1b3e78d2bbb264046d4e7260f12184dd"
+  integrity sha512-w7aJnV30jc7OsiZQNPVmBc+HooZuvQZIZIShKutC3tnMFMkcwVN9CZRRSSNw03OnSCKmEkK8usmwcw6dqBaLzw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
React 16.8 officially supports hooks now. I applied them in this PR to make the code base a little lighter. I am not done with all the components yet, as I have another PR in the making that will introduce some major changes to the footer and the content component.