### PR TITLE
feat: Allow line-breaks in JSON input

### DIFF
--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -41,7 +41,7 @@ const demoJson = JSON.stringify({age: 50, name: 'Sophie'});
 
 const formatJSON = (json: string) => {
   try {
-    const object = json5.parse(json.replace(/(\r\n|\n|\r)/gm, ''));
+    const object = json5.parse(json.replace(/[\r\n]/gm, ''));
     const sorted = jsonAbc.sortObj(object, true);
     return JSON.stringify(sorted, null, 2);
   } catch (error) {

--- a/src/components/layout/Content.tsx
+++ b/src/components/layout/Content.tsx
@@ -41,7 +41,7 @@ const demoJson = JSON.stringify({age: 50, name: 'Sophie'});
 
 const formatJSON = (json: string) => {
   try {
-    const object = json5.parse(json);
+    const object = json5.parse(json.replace(/(\r\n|\n|\r)/gm, ''));
     const sorted = jsonAbc.sortObj(object, true);
     return JSON.stringify(sorted, null, 2);
   } catch (error) {


### PR DESCRIPTION
**Description**

When copying JSON strings from the terminal it may happen that a JSON construct goes over serveral terminal lines and thus includes line-breaks. Actually the line-breaks don't hurt the content but they have to be removed in order to properly show up in Sort JSON.

**Before**

![image](https://user-images.githubusercontent.com/469989/92232672-3723c500-eeaf-11ea-92f9-fb044f04eeca.png)

**After**

![image](https://user-images.githubusercontent.com/469989/92232723-4d318580-eeaf-11ea-8cdc-1c11d9b66827.png)

