### PR TITLE
chore: Pin Docker image digests and add Dependabot docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 99
+    assignees:
+      - ffflorian
+    versioning-strategy: increase
   - package-ecosystem: npm
     directory: '/'
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM node:24-alpine AS builder
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ RUN yarn install --immutable
 RUN yarn build
 
 # Serve
-FROM nginx:alpine
+FROM nginx:alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- pin Docker base images to current digests
- pin Dockerfile-installed packages where they are managed directly in the Dockerfile
- add or update Dependabot Docker configuration with monthly updates for @ffflorian
